### PR TITLE
Update zarr-python repo name

### DIFF
--- a/dashboard.yml
+++ b/dashboard.yml
@@ -95,7 +95,7 @@
     appveyor_project: philippjfr/hvplot
     badges: travis, appveyor, coveralls, rtd, pypi, conda, conda-forge, defaults
 
-  - repo: zarr-developers/zarr
+  - repo: zarr-developers/zarr-python
     badges: travis, appveyor, coveralls, rtd, pypi, conda-forge, defaults
 
   - repo: Unidata/netcdf4-python


### PR DESCRIPTION
Hopefully this will fix the unknown travis status:

![Screen Shot 2020-05-06 at 23 53 34](https://user-images.githubusercontent.com/88113/81232264-dc5b8900-8ff4-11ea-900b-18d9473dfc46.png)
